### PR TITLE
fix: correct docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 .DS_Store
-chroma_data/*
 node_modules/
-docs/*

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This implements simple RAG with Ollama and ChromaDB.
 
 ## How do I use it?
 1) Copy HTML/Markdown/Text files into the ./docs directory.
-2) Start up the applications. Run `docker compose up -d`
-3) Once service "init" has exited, run `node client.js init`
-4) Once this is finished, run `node client.js search "{your question}"`, as many times as you want.
+2) Run `npm install`
+3) Start up the applications. Run `docker compose up -d`. 
+4) Watch for status of `init` container with `docker compose logs --follow init`.
+5) Once service "init" has exited, run `npm run init`.
+6) Once this is finished, run `npm run search "{your question}"`, as many times as you want.

--- a/chroma_data/.gitignore
+++ b/chroma_data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ networks:
   main:
 services:
   model:
-    build:
-      context: .
-      dockerfile: Ollama.Dockerfile
+    image: ollama/ollama
     ports:
       - "11434:11434"
     networks: ['main']

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "rag",
+  "name": "simple-rag",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rag",
+      "name": "simple-rag",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "chromadb": "^1.10.4",
         "chromadb-default-embed": "^2.13.2",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "rag",
+  "name": "simple-rag",
+  "private": true,
   "version": "1.0.0",
-  "description": "## Tools: ChromaDB Docker",
+  "description": "Simple RAG implementation",
   "main": "client.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Tests not implemented\"",
+    "init": "node client.js init",
+    "search": "node client.js search"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "chromadb": "^1.10.4",
     "chromadb-default-embed": "^2.13.2",


### PR DESCRIPTION
- service "model" was still pointing to a Dockerfile no longer in use.
- cleaned up package.json a bit, including "init" and "search" scripts.
- added .gitignore files as placeholders for chroma_data and docs folders.
- updated README to revise steps to using the tool.